### PR TITLE
clear-db.bash: auto-derive DynamoDB table tables from env

### DIFF
--- a/clear-db.bash
+++ b/clear-db.bash
@@ -36,6 +36,18 @@ function clear_regular_table() {
 }
 
 
-clear_delta_table 'ds' 'dbname'
-clear_regular_table 'dbname'
+amplify_meta='amplify/#current-cloud-backend/amplify-meta.json'
+json_path='.api[].output.GraphQLAPIIdOutput'
+special_id="$(cat $amplify_meta | jq -r $json_path)"
+
+local_env_info='amplify/.config/local-env-info.json'
+env_name="$(cat $local_env_info | jq -r '.envName')"
+
+schema_files='amplify//#current-cloud-backend/api/*/schema.graphql'
+model_names=($(cat $schema_files | awk '/@model/ { print $2 }'))
+
+clear_delta_table 'ds' "AmplifyDataStore-${special_id}-${env_name}"
+for model_name in ${model_names[@]}; do
+    clear_regular_table "${model_name}-${special_id}-${env_name}"
+done
 


### PR DESCRIPTION
The `./clear-db.sh` can be used to empty out DynamoDB tables that back an AppSync endpoint used with Amplify DataStore. This script is useful during development, at times when you want to start from a clean slate, without re-provisioning an entire new AppSync endpoint.

Previously, it was necessary to manually update the script before running it, to include the names of relevant Dynamo DB tables.

Now, the names of the tables are derived directly from information in the project environment.

There is no longer a need to manually update the script, and there is no need to provide an arguments.