### PR TITLE
Update to RxJava3

### DIFF
--- a/app/src/main/java/com/amplifyframework/datastore/sample/LocalDataStoreInteractor.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/LocalDataStoreInteractor.kt
@@ -7,9 +7,9 @@ import com.amplifyframework.datastore.sample.LocalPresentation.PostInteractor
 import com.amplifyframework.rx.RxAuthCategoryBehavior
 import com.amplifyframework.rx.RxDataStoreCategoryBehavior
 
-import io.reactivex.Completable
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 import java.lang.RuntimeException
 
 internal class LocalDataStoreInteractor(

--- a/app/src/main/java/com/amplifyframework/datastore/sample/LocalPresentation.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/LocalPresentation.kt
@@ -4,9 +4,9 @@ import android.util.Pair
 
 import com.amplifyframework.datastore.generated.model.Post
 
-import io.reactivex.Completable
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 
 @Suppress("unused") // The sub-interface are, though. Lint doesn't catch that.
 internal interface LocalPresentation {

--- a/app/src/main/java/com/amplifyframework/datastore/sample/LocalPresenter.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/LocalPresenter.kt
@@ -8,9 +8,9 @@ import com.amplifyframework.datastore.sample.LocalPresentation.PostInteractor
 import com.amplifyframework.datastore.sample.LocalPresentation.Presenter
 import com.amplifyframework.datastore.sample.LocalPresentation.View
 
-import io.reactivex.Observable
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.functions.Consumer
 
 internal class LocalPresenter(
         private val interactor: PostInteractor,

--- a/app/src/main/java/com/amplifyframework/datastore/sample/RemoteApiInteractor.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/RemoteApiInteractor.kt
@@ -4,9 +4,9 @@ import com.amplifyframework.datastore.appsync.ModelWithMetadata
 import com.amplifyframework.datastore.generated.model.Post
 import com.amplifyframework.datastore.sample.RemotePresentation.ApiInteractor
 
-import io.reactivex.Observable
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 internal class RemoteApiInteractor(private val appSync: RxAppSyncClient) : ApiInteractor {
     override fun createRandom(): Single<ModelWithMetadata<Post>> =

--- a/app/src/main/java/com/amplifyframework/datastore/sample/RemotePresentation.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/RemotePresentation.kt
@@ -3,8 +3,8 @@ package com.amplifyframework.datastore.sample
 import com.amplifyframework.datastore.appsync.ModelWithMetadata
 import com.amplifyframework.datastore.generated.model.Post
 
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 
 internal interface RemotePresentation {
     interface View {

--- a/app/src/main/java/com/amplifyframework/datastore/sample/RemotePresenter.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/RemotePresenter.kt
@@ -6,7 +6,7 @@ import com.amplifyframework.datastore.sample.RemotePresentation.ApiInteractor
 import com.amplifyframework.datastore.sample.RemotePresentation.Presenter
 import com.amplifyframework.datastore.sample.RemotePresentation.View
 
-import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 internal class RemotePresenter(private val interactor: ApiInteractor, private val view: View) : Presenter {
     private val ongoingOperations: CompositeDisposable = CompositeDisposable()

--- a/app/src/main/java/com/amplifyframework/datastore/sample/RxAppSyncClient.kt
+++ b/app/src/main/java/com/amplifyframework/datastore/sample/RxAppSyncClient.kt
@@ -2,22 +2,23 @@ package com.amplifyframework.datastore.sample
 
 import com.amplifyframework.api.graphql.GraphQLBehavior
 import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.api.graphql.PaginatedResult
 import com.amplifyframework.core.model.Model
 import com.amplifyframework.datastore.appsync.AppSync
 import com.amplifyframework.datastore.appsync.AppSyncClient
 import com.amplifyframework.datastore.appsync.ModelWithMetadata
 
-import io.reactivex.Observable
-import io.reactivex.ObservableEmitter
-import io.reactivex.Single
-import io.reactivex.SingleEmitter
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableEmitter
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.core.SingleEmitter
 
 internal class RxAppSyncClient(graphQlBehavior: GraphQLBehavior) {
     private val appSyncClient: AppSync = AppSyncClient.via(graphQlBehavior)
 
     fun <T : Model> sync(clazz: Class<T>): Observable<ModelWithMetadata<T>> {
-        return Observable.create { emitter: ObservableEmitter<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> ->
-            appSyncClient.sync(clazz, null,
+        return Observable.create { emitter: ObservableEmitter<GraphQLResponse<PaginatedResult<ModelWithMetadata<T>>>> ->
+            appSyncClient.sync(appSyncClient.buildSyncRequest(clazz, null, null),
                  { emitter.onNext(it) },
                  { emitter.onError(it) }
             )


### PR DESCRIPTION
Updates sample app to work with amplify-android 1.4.1
 - Update to RxJava3
 - Update due to change in DataStore's `AppSync` interface